### PR TITLE
Aggregate provinces of a single country to a single table row.

### DIFF
--- a/countrymap.js
+++ b/countrymap.js
@@ -181,7 +181,7 @@ var countryToCodeMap = {
 'Qatar': 'QA',
 'Réunion': 'RE',
 'Romania': 'RO',
-'Russian Federation': 'RU',
+'Russia': 'RU',
 'Rwanda': 'RW',
 'Saint Barthélemy': 'BL',
 'Saint Helena, Ascension and Tristan da Cunha': 'SH',
@@ -249,3 +249,5 @@ var countryToCodeMap = {
 'Zambia': 'ZM',
 'Zimbabwe': 'ZW',
 }
+
+var codeToENMap = reverseObject(countryToCodeMap);

--- a/map.js
+++ b/map.js
@@ -65,12 +65,26 @@ function renderCounters() {
 }
 
 function renderCountryList(id, countries) {
+  var aggregated = {}
   for (var elem of countries) {
     var country = getCountry(elem);
-    if (country.length != 2) {
-      country = countryToCodeMap[elem];
+    if (!(country in aggregated)) {
+      aggregated[country] = [];
     }
-    var country_html = elem + " <img class='flag' src='flags-iso/" + country + ".png'><br>";
+    aggregated[country].push(getProvince(elem));
+  }
+  for (var elem in aggregated) {
+    var country_code = getCountryCode(elem);
+    var country_html = codeToENMap[country_code];
+    if (aggregated[elem].length > 1 || aggregated[elem][0] !== '') {
+      country_html += ': <small>';
+      for (province of aggregated[elem]) {
+        country_html += province + ', ';
+      }
+      country_html = country_html.slice(0, -2) + '</small>';
+    }
+    var flag_html = " <img class='flag' src='flags-iso/" + country_code + ".png'><br>";
+    country_html += flag_html
     document.getElementById(id).innerHTML += country_html;
   }
 }
@@ -82,7 +96,23 @@ function renderCountryLists() {
 }
 
 function getCountry(country_or_province) {
-  return country_or_province.split('-')[0]
+  return country_or_province.split('-')[0];
+}
+
+function getProvince(country_or_province) {
+  name_parts = country_or_province.split('-');
+  if (name_parts.length > 1) {
+    return name_parts[1];
+  }
+  return '';
+}
+
+function getCountryCode(country_or_province) {
+  var country = getCountry(country_or_province);
+  if (country.length != 2) {
+    country = countryToCodeMap[country_or_province];
+  }
+  return country;
 }
 
 function countCountries(countries) {

--- a/utils.js
+++ b/utils.js
@@ -23,3 +23,11 @@ function difference(A, B) {
   }
   return diff;
 }
+
+function reverseObject(obj) {
+  var reversed = {}
+  for (var key in obj) {
+    reversed[obj[key]] = key;
+  }
+  return reversed;
+}


### PR DESCRIPTION
As some countries are visualized on a region level, we would like these
regions to be grouped together in a single entry.

Additionally, this patch takes care of visual discrepancy between these
fine-grained region codes and a simple country name. As a side effect,
names in data.js can be specified by either full name of by 2 letter country code.